### PR TITLE
Possibility to parse a DBC represented as string

### DIFF
--- a/src/main/java/com/github/canbabel/canio/ui/MainFrame.java
+++ b/src/main/java/com/github/canbabel/canio/ui/MainFrame.java
@@ -17,8 +17,6 @@
  **/
 package com.github.canbabel.canio.ui;
 
-// TODO Version number(major.minor.build)
-import com.github.canbabel.canio.dbc.DbcReader;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -28,11 +26,15 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.prefs.*;
+import java.util.prefs.Preferences;
 import java.util.zip.GZIPInputStream;
+
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.xml.transform.stream.StreamSource;
+
+// TODO Version number(major.minor.build)
+import com.github.canbabel.canio.dbc.DbcReader;
 
 /**
  * User interface
@@ -140,7 +142,8 @@ public class MainFrame extends javax.swing.JFrame {
 
         convertButton.setText("Convert");
         convertButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            @Override
+			public void actionPerformed(java.awt.event.ActionEvent evt) {
                 convertButtonActionPerformed(evt);
             }
         });
@@ -217,7 +220,8 @@ public class MainFrame extends javax.swing.JFrame {
 
         addFilesOrFoldersButton.setText("Add files or folders");
         addFilesOrFoldersButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            @Override
+			public void actionPerformed(java.awt.event.ActionEvent evt) {
                 addFilesOrFoldersButtonActionPerformed(evt);
             }
         });
@@ -243,7 +247,8 @@ public class MainFrame extends javax.swing.JFrame {
 
         removeButton.setText("Remove");
         removeButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            @Override
+			public void actionPerformed(java.awt.event.ActionEvent evt) {
                 removeButtonActionPerformed(evt);
             }
         });
@@ -283,7 +288,8 @@ public class MainFrame extends javax.swing.JFrame {
         closeButton.setMaximumSize(new java.awt.Dimension(68, 30));
         closeButton.setMinimumSize(new java.awt.Dimension(68, 30));
         closeButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            @Override
+			public void actionPerformed(java.awt.event.ActionEvent evt) {
                 closeButtonHandler(evt);
             }
         });
@@ -409,7 +415,7 @@ public class MainFrame extends javax.swing.JFrame {
 
         if (dbcfile.canRead()) {
             DbcReader reader = new DbcReader();
-            if (reader.parseFile(dbcfile, System.out)) {
+            if (reader.parseFile(dbcfile, System.out, null)) {
                 reader.writeKcdFile(kcdfile, true, false);
 
                 /* Validate the result */
@@ -520,7 +526,7 @@ public class MainFrame extends javax.swing.JFrame {
                 try {
                     DbcReader reader = new DbcReader();
                     reader.omitUnconsumedSignals(uselessCheckbox.isSelected());
-                    if (reader.parseFile(f, logOutput)) {
+                    if (reader.parseFile(f, logOutput, null)) {
                         reader.writeKcdFile(newFile, prettyprintCheckbox.isSelected(), gzippedCheckbox.isSelected());
 
                         /* Validate the result */

--- a/src/test/java/com/github/canbabel/canio/dbc/CANFDTest.java
+++ b/src/test/java/com/github/canbabel/canio/dbc/CANFDTest.java
@@ -1,15 +1,17 @@
 package com.github.canbabel.canio.dbc;
 
-import org.junit.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import com.github.canbabel.canio.kcd.Bus;
 import com.github.canbabel.canio.kcd.Message;
 import com.github.canbabel.canio.kcd.NetworkDefinition;
-
-import static org.junit.Assert.*;
-
-import java.io.File;
-import java.net.URL;
 
 public class CANFDTest {
 
@@ -23,7 +25,7 @@ public class CANFDTest {
         dr = new DbcReader();
         URL url = Thread.currentThread().getContextClassLoader().getResource("canfdtest.dbc");
         File testFile = new File(url.getPath());
-        dr.parseFile(testFile, System.out);
+        dr.parseFile(testFile, System.out, null);
     }
 
     /**

--- a/src/test/java/com/github/canbabel/canio/dbc/DbcReaderTest.java
+++ b/src/test/java/com/github/canbabel/canio/dbc/DbcReaderTest.java
@@ -17,19 +17,22 @@
  **/
 package com.github.canbabel.canio.dbc;
 
-import java.io.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
 import java.net.URL;
-import java.util.zip.GZIPInputStream;
 
-import com.github.canbabel.canio.ui.SchemaValidator;
-import org.junit.*;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
-import static org.junit.Assert.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.github.canbabel.canio.ui.SchemaValidator;
 
 /**
  * @author Jan-Niklas Meier < dschanoeh@googlemail.com >
@@ -153,7 +156,7 @@ public class DbcReaderTest {
         DbcReader reader = new DbcReader();
         File readInTestKcdFile = new File("read_in_test.kcd");
 
-        if (reader.parseFile(testFile, System.out)) {
+        if (reader.parseFile(testFile, System.out, null)) {
             reader.writeKcdFile(readInTestKcdFile, true, false);
 
             StreamSource source = new StreamSource(readInTestKcdFile);


### PR DESCRIPTION
The current implementation allows only to parse DBCs from files.

With current changes, we can also parse DBCs from strings.

Also, we exposed the `bus` field from `DbcReader` (with a getter) class to use the parsed details about signals/messages outside the reader. 